### PR TITLE
FIX: modDir pathname. delete first / from pathname

### DIFF
--- a/packages/create-firebolt/src/index.js
+++ b/packages/create-firebolt/src/index.js
@@ -13,7 +13,7 @@ const __dirname = path.dirname(__filename)
 
 const green = chalk.green
 
-const modDir = new URL('.', import.meta.url).pathname
+const modDir = new URL('.', import.meta.url).pathname.substring(1)
 const pkgFile = path.join(modDir, '../package.json')
 
 const { version } = await fs.readJSON(pkgFile)


### PR DESCRIPTION
Hello. I tried to create the application using npm create firebolt@latest but failed due to an error with the paths.

When calling new URL('.', import.meta.url).pathname, I received a path that starts with the "/" character. Because of this, in the future, with path.join, the disk was added to the beginning again.
![glIw9lT5zoE](https://github.com/firebolt-dev/firebolt/assets/29573766/3a97f554-db8b-4363-aedc-8f02fea3cf56)

If you remove the "/" the error disappears and everything works.
![p3qjUYAjb0I](https://github.com/firebolt-dev/firebolt/assets/29573766/3a5a2f8f-07a2-4efb-8344-53f06a7a9b10)
